### PR TITLE
Add support for releasing and generating executable JAR files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-models/
-.idea/
-tmp/
+models
+.idea
+tmp
 /src/test/resources/
+release

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,29 @@
-apply plugin: 'idea'
 apply plugin: 'java'
 
 repositories {
-	mavenLocal()
-	jcenter()
-	mavenCentral()
+    mavenLocal()
+    jcenter()
+    mavenCentral()
 }
 
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.+'
+}
+
+jar {
+    version '1.0'
+    manifest {
+        attributes("Main-Class": "org.thunlp.thulac.main.Main")
+    }
+}
+
+task release(dependsOn: 'jar') {
+    copy {
+        from 'build/libs'
+        into 'release'
+    }
+    copy {
+        from 'models'
+        into 'release/models'
+    }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'thulac'


### PR DESCRIPTION
After this, users can clone this repo to their own computers and execure:
        gradle release
to generate an executable JAR file at `/release`.
p.s. Though positions can be changed using the command line switch `-model_dir`, the model files used by this library are defaulted to locate under `/models`. Therefore these files are copied to `/release/models` while executing the `release` task, allowing users to start a console under `/release` and type in `java -jar thulac-1.0.jar -input <input_file> -output <output_file>` to run the library.

This pull request is used to sync the my forked repo with this one, after which I will continue to develop here.